### PR TITLE
Allow yaml files

### DIFF
--- a/Test-YamlADOPipeline.ps1
+++ b/Test-YamlADOPipeline.ps1
@@ -34,8 +34,8 @@ param (
                 throw "File or Path does not exist."
             }
 
-            if ($_ -notmatch "(\.yml)") {
-                throw "The file specified in the path must be of type yml."
+            if ($_ -notmatch "(\.ya?ml)") {
+                throw "The file specified in the path must be of type yml or yaml."
             }
 
             return $true


### PR DESCRIPTION
He John,

I'm using this validator, thx man for making this cli tool wrapping the post to the devops API! 
I noticed that the SYSTEM.ACCESSTOKEN does not have the Build - Read & Execute unfortunately. So I have created a PAT.

Extend regex matcher to allow `yaml` and `yaml`