### PR TITLE
When PAT token expires, give a hint.

### DIFF
--- a/Test-YamlADOPipeline.ps1
+++ b/Test-YamlADOPipeline.ps1
@@ -85,6 +85,19 @@ try {
     Add-CustomObjectProperties -Object $restOutput
 }
 catch {
-    Write-Error ($_.ErrorDetails.Message | ConvertFrom-Json).Message
+    $ErrorMessage = $_.Exception.Message
+    
+    try { 
+        # If it's json
+        Write-Error ($ErrorMessage | ConvertFrom-Json).Message
+    } 
+    catch {
+        # In case it's something else, when it's not parsable....
+        Write-Host "Make sure the PersonalAccessToken is valid."
+        Write-Host "To update the PAT, edit the Pipeline and update the Variable with a valid token with permissions: Build read+execute!"
+        Write-Error $ErrorMessage
+    }
     exit 1
 }
+    
+


### PR DESCRIPTION
When the token is not valid, the error does NOT contain JSON and the catch raises another exception.